### PR TITLE
Add null check for player

### DIFF
--- a/src/main/java/me/mattyhd0/chatcolor/placeholderapi/ChatColorPlaceholders.java
+++ b/src/main/java/me/mattyhd0/chatcolor/placeholderapi/ChatColorPlaceholders.java
@@ -39,7 +39,7 @@ public class ChatColorPlaceholders extends PlaceholderExpansion {
 
     public String onPlaceholderRequest(Player player, String identifier) {
 
-        CPlayer cPlayer = ChatColorPlugin.getInstance().getDataMap().get(player.getUniqueId());
+        CPlayer cPlayer = player != null ? ChatColorPlugin.getInstance().getDataMap().get(player.getUniqueId()) : null;
 
         if (cPlayer == null) {
             return "";


### PR DESCRIPTION
Fixes exception being thrown for null player values.
```
[11:37:04 WARN]: java.lang.NullPointerException: Cannot invoke "org.bukkit.entity.Player.getUniqueId()" because "player" is null
[11:37:04 WARN]:        at ChatColor-Fork-2.7.11.jar//me.mattyhd0.chatcolor.placeholderapi.ChatColorPlaceholders.onPlaceholderRequest(ChatColorPlaceholders.java:42)
[11:37:04 WARN]:        at PlaceholderAPI-2.11.6.jar//me.clip.placeholderapi.PlaceholderHook.onRequest(PlaceholderHook.java:35)
```